### PR TITLE
chore: remove resource that does live up to expected quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,3 @@ A curated list of resources or projects related to ox_core.
 ### Miscellaneous Systems
 
 - [fivem-attributes](https://github.com/arlofonseca/fivem-attributes) - A simple player attributes system for setting and viewing details of a character.
-
-### Guides
-
-- [QB-TO-OX](https://github.com/jaanmangib/QB-TO-OX) - Helps to convert qb-core scripts to ox_core.


### PR DESCRIPTION
Unfortunately as much as we do want to have guides that clearly showcases how to convert from one framework to another this simply does not live up the quality that we expect.


Here is an example:
![image](https://github.com/user-attachments/assets/18205792-18a3-4cfe-9e52-450cb08141fd)
In this screenshot it says that ox_core has addAccountMoney and removeAccountMoney which just isn't the case the only way is to do something like:

```lua
local account = player.getAccount()

account.removeBalance({
    amount = 69420,
    message = "happy mothers day cutie",
    overdraw = true
})
```

which clearly is completely different from what the guide showcases.

this is just one of the numerous other mistakes in it but regardless this does NOT work and will not help anyone convert their scripts might just end up making them suffer more and blame the framework.